### PR TITLE
Don't call a cart "shared" when it isn't.

### DIFF
--- a/pretix_cartshare/locale/de/LC_MESSAGES/django.po
+++ b/pretix_cartshare/locale/de/LC_MESSAGES/django.po
@@ -54,12 +54,12 @@ msgstr "Gesamtbetrag"
 
 #: pretix_cartshare/signals.py:16
 #: pretix_cartshare/templates/pretixplugins/cartshare/list.html:17
-msgid "Share a cart"
+msgid "Create a cart"
 msgstr "Warenkorb verschicken"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/create.html:6
 #: pretix_cartshare/templates/pretixplugins/cartshare/create.html:9
-msgid "Create a shared cart"
+msgid "Create a cart"
 msgstr "Verschickbaren Warenkorb erstellen"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/create.html:17
@@ -76,7 +76,7 @@ msgstr "Speichern"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/delete.html:4
 #: pretix_cartshare/templates/pretixplugins/cartshare/delete.html:6
-msgid "Delete shared cart"
+msgid "Delete cart"
 msgstr "Warenkorb löschen"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/delete.html:9
@@ -95,17 +95,12 @@ msgstr "Abbrechen"
 msgid "Delete"
 msgstr "Löschen"
 
-#: pretix_cartshare/templates/pretixplugins/cartshare/list.html:5
-#: pretix_cartshare/templates/pretixplugins/cartshare/list.html:8
-msgid "Shared carts"
-msgstr "Warenkörbe"
-
 #: pretix_cartshare/templates/pretixplugins/cartshare/list.html:13
-msgid "No shared carts found."
+msgid "No carts found."
 msgstr "Keine Warenkörbe gefunden."
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/list.html:22
-msgid "Share a new cart"
+msgid "Create a new cart"
 msgstr "Verschickbaren Warenkorb erstellen"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/list.html:31

--- a/pretix_cartshare/locale/de_Informal/LC_MESSAGES/django.po
+++ b/pretix_cartshare/locale/de_Informal/LC_MESSAGES/django.po
@@ -54,12 +54,12 @@ msgstr "Gesamtbetrag"
 
 #: pretix_cartshare/signals.py:16
 #: pretix_cartshare/templates/pretixplugins/cartshare/list.html:17
-msgid "Share a cart"
+msgid "Create a cart"
 msgstr "Warenkorb verschicken"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/create.html:6
 #: pretix_cartshare/templates/pretixplugins/cartshare/create.html:9
-msgid "Create a shared cart"
+msgid "Create a cart"
 msgstr "Verschickbaren Warenkorb erstellen"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/create.html:17
@@ -76,7 +76,7 @@ msgstr "Speichern"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/delete.html:4
 #: pretix_cartshare/templates/pretixplugins/cartshare/delete.html:6
-msgid "Delete shared cart"
+msgid "Delete cart"
 msgstr "Warenkorb löschen"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/delete.html:9
@@ -95,17 +95,12 @@ msgstr "Abbrechen"
 msgid "Delete"
 msgstr "Löschen"
 
-#: pretix_cartshare/templates/pretixplugins/cartshare/list.html:5
-#: pretix_cartshare/templates/pretixplugins/cartshare/list.html:8
-msgid "Shared carts"
-msgstr "Warenkörbe"
-
 #: pretix_cartshare/templates/pretixplugins/cartshare/list.html:13
-msgid "No shared carts found."
+msgid "No carts found."
 msgstr "Keine Warenkörbe gefunden."
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/list.html:22
-msgid "Share a new cart"
+msgid "Create a new cart"
 msgstr "Verschickbaren Warenkorb erstellen"
 
 #: pretix_cartshare/templates/pretixplugins/cartshare/list.html:31

--- a/pretix_cartshare/templates/pretixplugins/cartshare/create.html
+++ b/pretix_cartshare/templates/pretixplugins/cartshare/create.html
@@ -3,10 +3,10 @@
 {% load bootstrap3 %}
 {% load formset_tags %}
 
-{% block title %}{% trans "Create a shared cart" %}{% endblock %}
+{% block title %}{% trans "Create a cart" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Create a shared cart" %}</h1>
+    <h1>{% trans "Create a cart" %}</h1>
     <form action="" method="post">
         {% csrf_token %}
         <div class="form-horizontal">

--- a/pretix_cartshare/templates/pretixplugins/cartshare/delete.html
+++ b/pretix_cartshare/templates/pretixplugins/cartshare/delete.html
@@ -1,9 +1,9 @@
 {% extends "pretixcontrol/event/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
-{% block title %}{% trans "Delete shared cart" %}{% endblock %}
+{% block title %}{% trans "Delete cart" %}{% endblock %}
 {% block content %}
-	<h1>{% trans "Delete shared cart" %}</h1>
+	<h1>{% trans "Delete cart" %}</h1>
 	<form action="" method="post" class="form-horizontal">
 		{% csrf_token %}
 		<p>{% blocktrans %}Are you sure you want to delete the shared cart <strong>{{ cart.cart_id }}</strong>?{% endblocktrans %}</p>

--- a/pretix_cartshare/templates/pretixplugins/cartshare/list.html
+++ b/pretix_cartshare/templates/pretixplugins/cartshare/list.html
@@ -2,24 +2,24 @@
 {% load i18n %}
 {% load eventurl %}
 
-{% block title %}{% trans "Shared carts" %}{% endblock %}
+{% block title %}{% trans "Share a cart" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Shared carts" %}</h1>
+    <h1>{% trans "Carts" %}</h1>
 
     {% if carts|length == 0 %}
         <div class="empty-collection">
             <p>
-                {% trans "No shared carts found." %}
+                {% trans "No carts found." %}
             </p>
 
             <a href="{% url "plugins:pretix_cartshare:create" organizer=request.event.organizer.slug event=request.event.slug %}"
-                    class="btn btn-primary btn-lg"><i class="fa fa-plus"></i> {% trans "Share a cart" %}</a>
+                    class="btn btn-primary btn-lg"><i class="fa fa-plus"></i> {% trans "Create a cart" %}</a>
         </div>
     {% else %}
         <p>
             <a href="{% url "plugins:pretix_cartshare:create" organizer=request.event.organizer.slug event=request.event.slug %}" class="btn
-btn-default"><i class="fa fa-plus"></i> {% trans "Share a new cart" %}
+btn-default"><i class="fa fa-plus"></i> {% trans "Create a new cart" %}
             </a>
         </p>
         <div class="table-responsive">


### PR DESCRIPTION
Since we are in the context of the "share a cart" app/menu/etc, we can
safely call the list just a list of Carts. Also, use wording like
"Create a cart" instead of "Share a cart"